### PR TITLE
使TelegramBot.id 返回 ticket.token 而不是 user.id, 并增加新的属性 `userId`; 以及修复bot启动时未初始化用户信息的问题

### DIFF
--- a/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/bot/TelegramBot.kt
+++ b/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/bot/TelegramBot.kt
@@ -64,14 +64,21 @@ public interface TelegramBot : Bot {
         get() = userInfo.username ?: userInfo.firstName
 
     /**
-     * The id of current bot.
+     * The id of [userInfo].
      *
-     * @throws IllegalStateException The bot has not been started, or has never been used [queryUserInfo].
-     * @see userInfo
+     * @throws IllegalStateException The bot has not be started,
+     * or has never been used [queryUserInfo]
+     */
+    public val userId: ID
+        get() = userInfo.id.ID
+
+    /**
+     * The bot token configured.
      *
+     * If you want to get the `user.id` of this bot,
+     * use [userId].
      */
     override val id: ID
-        get() = userInfo.id.ID
 
     /**
      * Query user info of the current bot.

--- a/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/bot/internal/TelegramBotImpl.kt
+++ b/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/bot/internal/TelegramBotImpl.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.sync.withLock
 import love.forte.simbot.annotations.FragileSimbotAPI
 import love.forte.simbot.bot.JobBasedBot
 import love.forte.simbot.common.id.ID
-import love.forte.simbot.common.id.literal
+import love.forte.simbot.common.id.StringID.Companion.ID
+import love.forte.simbot.common.id.toLongOrNull
 import love.forte.simbot.component.telegram.core.bot.StdlibBot
 import love.forte.simbot.component.telegram.core.bot.TelegramBot
 import love.forte.simbot.component.telegram.core.bot.TelegramBotConfiguration
@@ -71,6 +72,8 @@ internal class TelegramBotImpl(
     internal val logger = LoggerFactory.getLogger("love.forte.simbot.component.telegram.core.bot")
     internal val eventLogger = LoggerFactory.getLogger("love.forte.simbot.component.telegram.stdlib.bot.event")
 
+    override val id: ID = source.ticket.token.ID
+
     private var _userInfo: User? = null
 
     override val userInfo: User
@@ -83,10 +86,10 @@ internal class TelegramBotImpl(
     }
 
     override fun isMe(id: ID): Boolean {
-        // TODO
-        return source.ticket.token == id.literal
-    }
+        val ui = _userInfo ?: return this.id == id
 
+        return this.id == id || ui.id == id.toLongOrNull()
+    }
 
     private val startLock = Mutex()
 
@@ -99,6 +102,9 @@ internal class TelegramBotImpl(
             }
 
             source.start()
+            // init bot user info
+            queryUserInfo()
+
             subscribeInternalProcessor(this, source, eventDispatcher)
 
             // mark started


### PR DESCRIPTION
`TelegramBot.id` 不应当是需要初始化的，且应该是用户所配置的

fix https://github.com/simple-robot/simpler-robot/issues/885