### PR TITLE
修复 `ChatMember` 的预期子类型 `ChatMemberMember` 实际上并未实现 `ChatMember` 的问题

### DIFF
--- a/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/actor/internal/AbstractTelegramChatGroupActor.kt
+++ b/simbot-component-telegram-core/src/commonMain/kotlin/love/forte/simbot/component/telegram/core/actor/internal/AbstractTelegramChatGroupActor.kt
@@ -60,6 +60,7 @@ internal abstract class AbstractTelegramChatGroupActor : TelegramChatGroupActor 
             is ChatMemberLeft -> chatMember.user.toTelegramMember(bot, chatMember)
             is ChatMemberOwner -> chatMember.user.toTelegramMember(bot, chatMember)
             is ChatMemberRestricted -> chatMember.user.toTelegramMember(bot, chatMember)
+            is ChatMemberMember -> chatMember.user.toTelegramMember(bot, chatMember)
         }
     }
 

--- a/simbot-component-telegram-type/src/commonMain/kotlin/love/forte/simbot/telegram/type/Chat.kt
+++ b/simbot-component-telegram-type/src/commonMain/kotlin/love/forte/simbot/telegram/type/Chat.kt
@@ -1209,7 +1209,7 @@ public data class ChatMemberMember(
      * type: `User`
      */
     public val user: User,
-)
+) : ChatMember()
 
 /**
  * [ChatMemberOwner](https://core.telegram.org/bots/api#chatmemberowner)


### PR DESCRIPTION
fix https://github.com/simple-robot/simpler-robot/issues/891